### PR TITLE
Retrieve only projects user has access to during validation.

### DIFF
--- a/de.weingardt.mylyn.gitlab.core/src/de/weingardt/mylyn/gitlab/core/ConnectionManager.java
+++ b/de.weingardt.mylyn.gitlab.core/src/de/weingardt/mylyn/gitlab/core/ConnectionManager.java
@@ -122,7 +122,7 @@ public class ConnectionManager {
 				projectPath = projectPath.substring(0, projectPath.length() - 4);
 			}
 
-			List<GitlabProject> projects = api.getProjects();
+			List<GitlabProject> projects = api.getMembershipProjects();
 			for(GitlabProject p : projects) {
 				if(p.getPathWithNamespace().equals(projectPath)) {
 					GitlabConnection connection = new GitlabConnection(host, p, token,


### PR DESCRIPTION
Validating causes the full public project list to be retrieved from the gitlab server.  When working on gitlab.com, this can cause eclipse to hang during validation as it retrieves every public project in the system. 

Changed the call from getProjects() to getMembershipProjects(),  which pulls only the projects that the user is a member of in some capacity - a small number of projects, rather than hundreds of thousands (millions?) of public repos available on gitlab.com.